### PR TITLE
Changing access for the var

### DIFF
--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -12,7 +12,7 @@ use Adamlc\AddressFormat\Exceptions\LocaleMissingFormatException;
  */
 class Format implements \ArrayAccess
 {
-    private $locale;
+    protected $locale;
 
     /**
      * This map specifies the content on how to format the address


### PR DESCRIPTION
This give the possibility to extend the class for specific methods
With a "private $locale" and without a "getLocale" method, it's not possible to access this var to write specific method by extending this class