### PR TITLE
Escape HTML output before adding <br> tags

### DIFF
--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -109,6 +109,7 @@ class Format implements \ArrayAccess
 
             //Replace new lines!
             if ($html) {
+                $formatted_address = htmlentities($formatted_address, ENT_QUOTES, 'UTF-8', false);
                 $formatted_address = str_replace('%n', "\n" . '<br>', $formatted_address);
             } else {
                 $formatted_address = trim(str_replace('%n', "\n", $formatted_address));


### PR DESCRIPTION
This change is somewhat opinionated, but I think it would be a good idea to escape the HTML output. Because the following line adds in HTML tags that needs to be preserved in the output, this line is the last opportunity to escape the address content itself.