### PR TITLE
Add #[\ReturnTypeWillChange] for PHP 8.1

### DIFF
--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -170,22 +170,26 @@ class Format implements \ArrayAccess
             $this->input_map[$key] = '';
         }
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->input_map[$offset]);
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->getAttribute($offset);
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->setAttribute($offset, $value);
     }
-    
+
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if ($this->offsetExists($offset)) {
@@ -219,6 +223,4 @@ class Format implements \ArrayAccess
             throw new LocaleMissingFormatException('Locale missing format');
         }
     }
-
-    
 }


### PR DESCRIPTION
This PR fix with PHP 8.1/8.2:
```
Return type of Adamlc\AddressFormat\Format::offsetExists($offset) should either be compatible
 with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute
 should be used to temporarily suppress the notice
```