### PR TITLE
Fix parameter 2 of str_replace with PHP 8.1

### DIFF
--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -100,7 +100,8 @@ class Format implements \ArrayAccess
 
             //Replace the street values
             foreach ($this->address_map as $key => $value) {
-                $formatted_address = str_replace('%' . $key, $this->input_map[$value], $formatted_address);
+                $replacement = empty($this->input_map[$value]) ? '' : $this->input_map[$value];
+                $formatted_address = str_replace('%' . $key, $replacement, $formatted_address);
             }
 
             //Remove blank lines from the resulting address


### PR DESCRIPTION
Source: [nicoka49](https://github.com/nicoka49/address-format/commit/ae501c51eb4a2affec0e6031be4cca9b4cf94cfa)
If I'm correct, this fix:
```
php8.1 -a
Interactive shell

php > error_reporting(E_ALL);
php > ini_set('display_errors', 1);
php > echo str_replace('a', null, 'b');
PHP Deprecated:  str_replace(): Passing null to parameter #2 ($replace) of type array|string
 is deprecated in php shell code on line 1
```

Not sure when it happen.