### PR TITLE
Remove %n in front and back of string

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -100,15 +100,19 @@ class Format implements \ArrayAccess
 
             //Replace the street values
             foreach ($this->address_map as $key => $value) {
-                $replacement = empty($this->input_map[$value]) ? '' : $this->input_map[$value];
-                $formatted_address = str_replace('%' . $key, $replacement, $formatted_address);
+                if( empty( $this->input_map[$value] ) ) {
+                    $key = '%' . $key . '%n'; // Also remove the %n newline otherwise it's being left there
+                    $replacement = '';
+                } else {
+                    $key = '%' . $key;
+                    $replacement = $this->input_map[$value];
+                }
+
+                $formatted_address = str_replace($key, $replacement, $formatted_address);
             }
 
             //Remove blank lines from the resulting address
             $formatted_address = preg_replace('((\%n)+)', '%n', $formatted_address);
-
-            //Remove %n in front and back of string
-            $formatted_address = trim($formatted_address, '%n');
 
             //Replace new lines!
             if ($html) {

--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -107,6 +107,8 @@ class Format implements \ArrayAccess
             //Remove blank lines from the resulting address
             $formatted_address = preg_replace('((\%n)+)', '%n', $formatted_address);
 
+            //Remove %n in front and back of string
+            $formatted_address = trim($formatted_address, '%n');
 
             //Replace new lines!
             if ($html) {

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -175,8 +175,7 @@ class FormatTest extends \PHPUnit\Framework\TestCase
 	$this->container->setAttribute('STREET_ADDRESS', 'Schulstrasse 4');
 
 	$this->assertEquals(
-		$this->container->formatAddress(),
-		"Schulstrasse 4\n32547 Oyenhausen"
+		$this->container->formatAddress(), "Schulstrasse 4\n32547 Oyenhausen"
 	);
     }
 

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -162,21 +162,21 @@ class FormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testDeAddressFormatWithMissingAttributes()
     {
-    	//Clear any previously set attributes
-    	$this->container->clearAttributes();
+        //Clear any previously set attributes
+        $this->container->clearAttributes();
 
-    	//Set Locale and attributes
-	$this->container->setLocale('DE');
+        //Set Locale and attributes
+        $this->container->setLocale('DE');
 
-	$this->container->setAttribute('LOCALITY', 'Oyenhausen');
-	$this->container->setAttribute('RECIPIENT', '');
-	$this->container->setAttribute('ORGANIZATION', '');
-	$this->container->setAttribute('POSTAL_CODE', '32547');
-	$this->container->setAttribute('STREET_ADDRESS', 'Schulstrasse 4');
+        $this->container->setAttribute('LOCALITY', 'Oyenhausen');
+        $this->container->setAttribute('RECIPIENT', '');
+        $this->container->setAttribute('ORGANIZATION', '');
+        $this->container->setAttribute('POSTAL_CODE', '32547');
+        $this->container->setAttribute('STREET_ADDRESS', 'Schulstrasse 4');
 
-	$this->assertEquals(
-		$this->container->formatAddress(), "Schulstrasse 4\n32547 Oyenhausen"
-	);
+        $this->assertEquals(
+            $this->container->formatAddress(), "Schulstrasse 4\n32547 Oyenhausen"
+        );
     }
 
     /**

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -60,10 +60,10 @@ class FormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testSetAttributeWithValidAttribute()
     {
-		$this->assertEquals(
-			$this->container->setAttribute('ADMIN_AREA', 'Foo Land'),
-			'Foo Land'
-		);
+        $this->assertEquals(
+            $this->container->setAttribute('ADMIN_AREA', 'Foo Land'),
+            'Foo Land'
+        );
     }
 
     /**
@@ -84,12 +84,12 @@ class FormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetAttributeWithValidAttribute()
     {
-    	$this->container->setAttribute('ADMIN_AREA', 'Foo Land');
+        $this->container->setAttribute('ADMIN_AREA', 'Foo Land');
 
-		$this->assertEquals(
-			$this->container->getAttribute('ADMIN_AREA'),
-			'Foo Land'
-		);
+        $this->assertEquals(
+            $this->container->getAttribute('ADMIN_AREA'),
+            'Foo Land'
+        );
     }
 
     /**
@@ -110,24 +110,24 @@ class FormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testGbAddressFormat()
     {
-    	//Clear any previously set attributes
-    	$this->container->clearAttributes();
+        //Clear any previously set attributes
+        $this->container->clearAttributes();
 
-    	//Set Locale and attributes
-		$this->container->setLocale('GB');
+        //Set Locale and attributes
+        $this->container->setLocale('GB');
 
-		$this->container->setAttribute('ADMIN_AREA', 'London');
-		$this->container->setAttribute('LOCALITY', 'Greenwich');
-		$this->container->setAttribute('RECIPIENT', 'Joe Bloggs');
-		$this->container->setAttribute('ORGANIZATION', 'Novotel London');
-		$this->container->setAttribute('POSTAL_CODE', 'SE10 8JA');
-		$this->container->setAttribute('STREET_ADDRESS', '173-185 Greenwich High Road');
-		$this->container->setAttribute('COUNTRY', 'United Kingdom');
+        $this->container->setAttribute('ADMIN_AREA', 'London');
+        $this->container->setAttribute('LOCALITY', 'Greenwich');
+        $this->container->setAttribute('RECIPIENT', 'Joe Bloggs');
+        $this->container->setAttribute('ORGANIZATION', 'Novotel London');
+        $this->container->setAttribute('POSTAL_CODE', 'SE10 8JA');
+        $this->container->setAttribute('STREET_ADDRESS', '173-185 Greenwich High Road');
+        $this->container->setAttribute('COUNTRY', 'United Kingdom');
 
-		$this->assertEquals(
-			$this->container->formatAddress(),
-			"Joe Bloggs\nNovotel London\n173-185 Greenwich High Road\nGreenwich\nSE10 8JA"
-		);
+        $this->assertEquals(
+            $this->container->formatAddress(),
+            "Joe Bloggs\nNovotel London\n173-185 Greenwich High Road\nGreenwich\nSE10 8JA"
+        );
     }
 
     /**
@@ -137,22 +137,22 @@ class FormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testDeAddressFormat()
     {
-    	//Clear any previously set attributes
-    	$this->container->clearAttributes();
+        //Clear any previously set attributes
+        $this->container->clearAttributes();
 
-    	//Set Locale and attributes
-		$this->container->setLocale('DE');
+        //Set Locale and attributes
+        $this->container->setLocale('DE');
 
-		$this->container->setAttribute('LOCALITY', 'Oyenhausen');
-		$this->container->setAttribute('RECIPIENT', 'Eberhard Wellhausen');
-		$this->container->setAttribute('ORGANIZATION', 'Wittekindshof');
-		$this->container->setAttribute('POSTAL_CODE', '32547');
-		$this->container->setAttribute('STREET_ADDRESS', 'Schulstrasse 4');
+        $this->container->setAttribute('LOCALITY', 'Oyenhausen');
+        $this->container->setAttribute('RECIPIENT', 'Eberhard Wellhausen');
+        $this->container->setAttribute('ORGANIZATION', 'Wittekindshof');
+        $this->container->setAttribute('POSTAL_CODE', '32547');
+        $this->container->setAttribute('STREET_ADDRESS', 'Schulstrasse 4');
 
-		$this->assertEquals(
-			$this->container->formatAddress(),
-			"Eberhard Wellhausen\nWittekindshof\nSchulstrasse 4\n32547 Oyenhausen"
-		);
+        $this->assertEquals(
+            $this->container->formatAddress(),
+            "Eberhard Wellhausen\nWittekindshof\nSchulstrasse 4\n32547 Oyenhausen"
+        );
     }
 
     /**
@@ -175,7 +175,8 @@ class FormatTest extends \PHPUnit\Framework\TestCase
         $this->container->setAttribute('STREET_ADDRESS', 'Schulstrasse 4');
 
         $this->assertEquals(
-            $this->container->formatAddress(), "Schulstrasse 4\n32547 Oyenhausen"
+            $this->container->formatAddress(),
+            "Schulstrasse 4\n32547 Oyenhausen"
         );
     }
 
@@ -222,39 +223,39 @@ class FormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testArrayAccess()
     {
-    	//Clear any previously set attributes
-    	$this->container->clearAttributes();
+        //Clear any previously set attributes
+        $this->container->clearAttributes();
 
-		$this->container['LOCALITY'] = 'Oyenhausen';
-		$this->container['RECIPIENT'] = 'Eberhard Wellhausen';
-		$this->container['ORGANIZATION'] = 'Wittekindshof';
-		$this->container['POSTAL_CODE'] = '32547';
-		$this->container['STREET_ADDRESS'] = 'Schulstrasse 4';
+        $this->container['LOCALITY'] = 'Oyenhausen';
+        $this->container['RECIPIENT'] = 'Eberhard Wellhausen';
+        $this->container['ORGANIZATION'] = 'Wittekindshof';
+        $this->container['POSTAL_CODE'] = '32547';
+        $this->container['STREET_ADDRESS'] = 'Schulstrasse 4';
 
-		$this->assertEquals(
-			$this->container['LOCALITY'],
-			'Oyenhausen'
-		);
+        $this->assertEquals(
+            $this->container['LOCALITY'],
+            'Oyenhausen'
+        );
 
-		$this->assertEquals(
-			$this->container['RECIPIENT'],
-			'Eberhard Wellhausen'
-		);
+        $this->assertEquals(
+            $this->container['RECIPIENT'],
+            'Eberhard Wellhausen'
+        );
 
-		$this->assertEquals(
-			$this->container['ORGANIZATION'],
-			'Wittekindshof'
-		);
+        $this->assertEquals(
+            $this->container['ORGANIZATION'],
+            'Wittekindshof'
+        );
 
-		$this->assertEquals(
-			$this->container['POSTAL_CODE'],
-			'32547'
-		);
+        $this->assertEquals(
+            $this->container['POSTAL_CODE'],
+            '32547'
+        );
 
-		$this->assertEquals(
-			$this->container['STREET_ADDRESS'],
-			'Schulstrasse 4'
-		);
+        $this->assertEquals(
+            $this->container['STREET_ADDRESS'],
+            'Schulstrasse 4'
+        );
     }
 
     /**
@@ -279,38 +280,38 @@ class FormatTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidAddressPieces()
     {
-    	//Clear any previously set attributes
-    	$this->container->clearAttributes();
+        //Clear any previously set attributes
+        $this->container->clearAttributes();
 
         //Set Locale
-	$this->container->setLocale('DE');
+        $this->container->setLocale('DE');
 
-	//get the ordered adress pieces for this locale
-	$validAddressPieces = $this->container->validAddressPieces();
+        //get the ordered adress pieces for this locale
+        $validAddressPieces = $this->container->validAddressPieces();
 
-	$this->assertEquals(
-		$validAddressPieces[0],
-		"RECIPIENT"
-	);
+        $this->assertEquals(
+            $validAddressPieces[0],
+            "RECIPIENT"
+        );
 
-	$this->assertEquals(
-		$validAddressPieces[1],
-		"ORGANIZATION"
-	);
+        $this->assertEquals(
+            $validAddressPieces[1],
+            "ORGANIZATION"
+        );
 
-	$this->assertEquals(
-		$validAddressPieces[2],
-		"STREET_ADDRESS"
-	);
+        $this->assertEquals(
+            $validAddressPieces[2],
+            "STREET_ADDRESS"
+        );
 
-	$this->assertEquals(
-		$validAddressPieces[3],
-		"POSTAL_CODE"
-	);
+        $this->assertEquals(
+            $validAddressPieces[3],
+            "POSTAL_CODE"
+        );
 
-	$this->assertEquals(
-		$validAddressPieces[4],
-		"LOCALITY"
-	);
+        $this->assertEquals(
+            $validAddressPieces[4],
+            "LOCALITY"
+        );
     }
 }

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -156,6 +156,31 @@ class FormatTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Check the format of a DE address is expected even when missing attributes
+     *
+     * @return void
+     */
+    public function testDeAddressFormatWithMissingAttributes()
+    {
+    	//Clear any previously set attributes
+    	$this->container->clearAttributes();
+
+    	//Set Locale and attributes
+	$this->container->setLocale('DE');
+
+	$this->container->setAttribute('LOCALITY', 'Oyenhausen');
+	$this->container->setAttribute('RECIPIENT', '');
+	$this->container->setAttribute('ORGANIZATION', '');
+	$this->container->setAttribute('POSTAL_CODE', '32547');
+	$this->container->setAttribute('STREET_ADDRESS', 'Schulstrasse 4');
+
+	$this->assertEquals(
+		$this->container->formatAddress(),
+		"Schulstrasse 4\n32547 Oyenhausen"
+	);
+    }
+
+    /**
      * Check that an exception is thrown for invlidate locale
      *
      * @return void


### PR DESCRIPTION
So if `RECIPIENT` or `ORGANIZATION` are not filled or empty, then this results in only a `STREET_ADDRESS` that's prefix with an `%n` which will be replace by a `<br>` which results in an address that's starts a line lower then needed.

Fixes #23