### PR TITLE
Fix hanging markers

### DIFF
--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -100,15 +100,7 @@ class Format implements \ArrayAccess
 
             //Replace the street values
             foreach ($this->address_map as $key => $value) {
-                if( empty( $this->input_map[$value] ) ) {
-                    $key = '%' . $key . '%n'; // Also remove the %n newline otherwise it's being left there
-                    $replacement = '';
-                } else {
-                    $key = '%' . $key;
-                    $replacement = $this->input_map[$value];
-                }
-
-                $formatted_address = str_replace($key, $replacement, $formatted_address);
+                $formatted_address = str_replace('%' . $key, $this->input_map[$value] ?: '', $formatted_address);
             }
 
             //Remove blank lines from the resulting address

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -181,6 +181,31 @@ class FormatTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Ensure that addresses doesn't leave markers hanging
+     *
+     * @return void
+     */
+    public function testSpanishAddressDoesntLeaveMarkersHanging()
+    {
+        //Clear any previously set attributes
+        $this->container->clearAttributes();
+
+        //Set Locale and attributes
+        $this->container->setLocale('es');
+
+        $this->container->setAttribute('LOCALITY', 'Girona');
+        $this->container->setAttribute('RECIPIENT', 'Jesper Jacobsen');
+        $this->container->setAttribute('POSTAL_CODE', '17001');
+        $this->container->setAttribute('STREET_ADDRESS', 'Gran Via De Jaume X, 123');
+
+        $this->assertEquals(
+            "Jesper Jacobsen\nGran Via De Jaume X, 123\n17001 Girona",
+            $this->container->formatAddress()
+        );
+    }
+
+
+    /**
      * Check that an exception is thrown for invlidate locale
      *
      * @return void


### PR DESCRIPTION
This fixes the issue introduced in #24, discussed in #25 with hanging %S markers.

A failing test was added, and subsequently fixed