### PR TITLE
Fix hanging newline 

### DIFF
--- a/src/Adamlc/AddressFormat/Format.php
+++ b/src/Adamlc/AddressFormat/Format.php
@@ -6,7 +6,9 @@ use Adamlc\AddressFormat\Exceptions\AttributeInvalidException;
 use Adamlc\AddressFormat\Exceptions\LocaleNotSupportedException;
 use Adamlc\AddressFormat\Exceptions\LocaleParseErrorException;
 use Adamlc\AddressFormat\Exceptions\LocaleMissingFormatException;
+use function array_filter;
 use function explode;
+use function trim;
 
 /**
  * Use this call to format a street address according to different locales
@@ -135,7 +137,9 @@ class Format implements \ArrayAccess
         $separator = $html ? '<br>' : "\n";
         $parts = explode($separator, $address);
 
-        $parts = array_filter($parts, 'strlen');
+        $parts = array_filter($parts, function ($part) {
+            return ! empty(trim($part));
+        });
         $parts = array_map('trim', $parts);
 
         $address = implode($separator, $parts);

--- a/tests/FormatTest.php
+++ b/tests/FormatTest.php
@@ -54,6 +54,29 @@ class FormatTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test setting a single attribute
+     *
+     * @return void
+     */
+    public function testSettingASingleAttribute()
+    {
+        $this->container->clearAttributes();
+        $this->container->setLocale('ES');
+
+        $this->container->setAttribute('RECIPIENT', '');
+        $this->container->setAttribute('ORGANIZATION', '');
+        $this->container->setAttribute('STREET_ADDRESS', '');
+        $this->container->setAttribute('POSTAL_CODE', '');
+        $this->container->setAttribute('LOCALITY', '');
+        $this->container->setAttribute('RECIPIENT', 'Jesper Jacobsen');
+
+        $this->assertEquals(
+            $this->container->formatAddress(),
+            "Jesper Jacobsen"
+        );
+    }
+
+    /**
      * Test setting a valid attribute
      *
      * @return void
@@ -308,10 +331,10 @@ class FormatTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * Check that an exception is thrown for validAddressPieces by invlidate locale
-    *
-    * @return void
-    */
+     * Check that an exception is thrown for validAddressPieces by invlidate locale
+     *
+     * @return void
+     */
     public function testValidAddressPiecesLocaleMissingFormatException()
     {
         //Clear any previously set attributes


### PR DESCRIPTION
Closes #28

Fixes a bug where if only certain attributes are filled in, newlines could hang, based on which locale was used.

Failing test added, and used to verify the fix.